### PR TITLE
add support to file connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ $ inspec detect -t k8s-container://default/shell-demo/nginx
  ────────────────────────────── Platform Details ──────────────────────────────
 
 Name:      k8s-container
-Families:  os
-Release:   1.1.1
+Families:  unix, os
+Release:   1.2.1
 Arch:      unknown
 ```
 
@@ -83,8 +83,8 @@ To find out how to use it, type: help
 You are currently running on:
 
     Name:      k8s-container
-    Families:  os
-    Release:   1.1.1
+    Families:  unix, os
+    Release:   1.2.1
     Arch:      unknown
 
 inspec>
@@ -94,11 +94,21 @@ inspec>
 
 The intended usage of this plugin is to allow `os`-platform-targeted profiles to run on Kubernetes containers. So, once you have connected, you should be able to run:
 
+#### example usage of [Inspec command resource](https://docs.chef.io/inspec/resources/command/)
 ```bash
 inspec> describe command("whoami") do
           its("stdout") { should cmp "alice" }
         end
 ```
+
+#### example usage of [Inspec file resource](https://docs.chef.io/inspec/resources/file/)
+```bash
+inspec> describe file('/proc/version') do
+           its('content') { should cmp "Linux version 6.5.11-linuxkit (root@buildkitsandbox) (gcc (Alpine 12.2.1_git20220924-r10) 12.2.1 20220924, GNU ld (GNU Binutils) 2.40) #1 SMP PREEMPT Wed Dec  6 17:08:31 UTC 2023\n" }
+        end
+```
+
+
 
 ## Reporting Issues
 

--- a/lib/train/k8s/container/connection.rb
+++ b/lib/train/k8s/container/connection.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "train"
+require "train/file/remote/linux"
 module Train
   module K8s
     module Container
@@ -40,6 +41,10 @@ module Train
 
         def run_command_via_connection(cmd, &_data_handler)
           KubectlExecClient.new(pod: pod, namespace: namespace, container_name: container_name).execute(cmd)
+        end
+
+        def file_via_connection(path, *_args)
+          ::Train::File::Remote::Linux.new(self, path)
         end
       end
     end

--- a/spec/train/k8s/container/connection_spec.rb
+++ b/spec/train/k8s/container/connection_spec.rb
@@ -46,5 +46,16 @@ RSpec.describe Train::K8s::Container::Connection do
         .with_message(/Error from server/)
     end
   end
+
+  describe "#file" do
+    let(:proc_version) { "Linux version 6.5.11-linuxkit (root@buildkitsandbox) (gcc (Alpine 12.2.1_git20220924-r10) 12.2.1 20220924, GNU ld (GNU Binutils) 2.40) #1 SMP PREEMPT Wed Dec  6 17:08:31 UTC 2023\n" }
+    let(:stdout) { proc_version }
+    before do
+      allow(kube_client).to receive(:execute).with("cat /proc/version || echo -n").and_return(shell_op)
+    end
+    it "executes a file connection" do
+      expect(subject.file("/proc/version").content).to eq(stdout)
+    end
+  end
 end
 

--- a/spec/train/k8s/container/platform_spec.rb
+++ b/spec/train/k8s/container/platform_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe Train::K8s::Container::Platform do
   end
 
   it "its platform family should be `os`" do
-    # TODO - this fails and we don't understand it yet
-    skip { expect(subject.platform.family).to eq("os") }
+    expect(subject.platform.family).to eq("unix")
   end
 end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Allow the train-k8s-container to be able to use Inspec file resource.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This change adds implicit file connections to the container using the k8s client. Currently it supports Linux/Unix based containers only.
- added specs to test file connections
- also updated documentation of usage for file and command resources

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
