### PR TITLE
Bug Fix shell run command

### DIFF
--- a/lib/train/k8s/container/connection.rb
+++ b/lib/train/k8s/container/connection.rb
@@ -30,7 +30,7 @@ module Train
         end
 
         def unique_identifier
-          uuid = @container_name
+          @unique_identifier ||= "#{@container_name}_#{@pod}"
         end
 
         private

--- a/lib/train/k8s/container/connection.rb
+++ b/lib/train/k8s/container/connection.rb
@@ -5,7 +5,6 @@ module Train
   module K8s
     module Container
       class Connection < Train::Plugins::Transport::BaseConnection
-        include Train::K8s::Container::Platform
 
         # URI format: k8s-container://<namespace>/<pod>/<container_name>
         # @example k8s-container://default/shell-demo/nginx

--- a/lib/train/k8s/container/kubectl_exec_client.rb
+++ b/lib/train/k8s/container/kubectl_exec_client.rb
@@ -45,7 +45,7 @@ module Train
         end
 
         def sh_run_command(command)
-          %W{/bin/sh -c '#{command}'}
+          %W{/bin/sh -c "#{command}"}
         end
       end
     end

--- a/lib/train/k8s/container/kubectl_exec_client.rb
+++ b/lib/train/k8s/container/kubectl_exec_client.rb
@@ -40,8 +40,12 @@ module Train
               arr << container_name
             end
             arr << "--"
-            arr << command
+            arr << sh_run_command(command)
           end.join("\s")
+        end
+
+        def sh_run_command(command)
+          %W{/bin/sh -c '#{command}'}
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Allow the transport to identify RHEL platform

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR does two following changes, 
- Remove the module `Train::K8s::Container::Platform` which implements force_platform!, so we rely on OS resources to define the platform based on the OS of the containers
- Update the run_command to execute commands via a Bourne Shell CLI

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
