### PR TITLE
Chef 11169 optimize k8s container connection v2

### DIFF
--- a/lib/train/k8s/container/kubectl_exec_client.rb
+++ b/lib/train/k8s/container/kubectl_exec_client.rb
@@ -40,7 +40,7 @@ module Train
               arr << container_name
             end
             arr << "--"
-            arr << sh_run_command(command)
+            arr << "/bin/sh"
           end.join("\s")
         end
 

--- a/lib/train/k8s/container/kubectl_exec_client.rb
+++ b/lib/train/k8s/container/kubectl_exec_client.rb
@@ -17,10 +17,8 @@ module Train
         end
 
         def execute(command)
-          instruction = build_instruction(command)
-          shell = Mixlib::ShellOut.new(instruction)
-          res = shell.run_command
-          Train::Extras::CommandResult.new(res.stdout, res.stderr, res.exitstatus)
+          ensure_session_open
+          stream(command)
         rescue Errno::ENOENT => _e
           Train::Extras::CommandResult.new("", "", 1)
         end

--- a/lib/train/k8s/container/kubectl_exec_client.rb
+++ b/lib/train/k8s/container/kubectl_exec_client.rb
@@ -9,15 +9,38 @@ module Train
   module K8s
     module Container
       class KubectlExecClient
-        attr_reader :pod, :container_name, :namespace
+        attr_reader :pod, :container_name, :namespace, :reader, :writer, :pid
 
         DEFAULT_NAMESPACE = "default".freeze
-        @@session = nil
+        @@session = {}
 
         def initialize(pod:, namespace: nil, container_name: nil)
           @pod = pod
           @container_name = container_name
           @namespace = namespace
+          if @@session.empty?
+            @reader = nil
+            @writer = nil
+            @pid = nil
+            connect
+          end
+        end
+
+        def connect
+          @reader, @writer, @pid = PTY.spawn("kubectl exec --stdin --tty #{@pod} -n #{@namespace} -c #{@container_name} -- /bin/bash")
+          @writer.sync = true
+          @@session[:reader] = @reader
+          @@session[:writer] = @writer
+          @@session[:pid] = @pid
+        rescue StandardError => e
+          puts "Error connecting: #{e.message}"
+          sleep 1
+          retry
+        end
+
+        def reconnect
+          disconnect
+          connect
         end
 
         def disconnect

--- a/lib/train/k8s/container/kubectl_exec_client.rb
+++ b/lib/train/k8s/container/kubectl_exec_client.rb
@@ -70,27 +70,18 @@ module Train
           raise "Failed to open connection" unless @@session
         end
 
-        def exec_command
-          ["kubectl exec"].tap do |arr|
-            arr << "--stdin"
-            arr << pod if pod
-            if namespace
-              arr << "-n"
-              arr << namespace
-            end
-            if container_name
-              arr << "-c"
-              arr << container_name
-            end
-            arr << "--"
-            arr << "/bin/sh"
-          end.join("\s")
+        def execute(command)
+          send_command(command)
+        rescue => e
+          reconnect
+          Train::Extras::CommandResult.new("", e.message, 1)
         end
 
-        def sh_run_command(command)
-          %W{/bin/sh -c "#{command}"}.join("\s")
+        def close
+          disconnect
         end
       end
     end
   end
 end
+

--- a/lib/train/k8s/container/kubectl_exec_client.rb
+++ b/lib/train/k8s/container/kubectl_exec_client.rb
@@ -1,6 +1,9 @@
 require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 require "train/options" # only to load the following requirement `train/extras`
 require "train/extras"
+require "open3"
+require "pty"
+require "expect"
 
 module Train
   module K8s

--- a/lib/train/k8s/container/kubectl_exec_client.rb
+++ b/lib/train/k8s/container/kubectl_exec_client.rb
@@ -35,7 +35,12 @@ module Train
         end
 
         def stream(command)
-          session.puts("#{command}; echo KUBECTL_EXEC_STATUS:$?; echo KUBECTL_EXEC_DONE")
+          instruction = [].tap do |com|
+            com << sh_run_command(command)
+            com << sh_run_command("echo KUBECTL_EXEC_STATUS:$?")
+            com << sh_run_command("echo KUBECTL_EXEC_DONE")
+          end.join(";\s")
+          session.puts(instruction)
           output = ""
           exit_status = nil
           while (line = session.gets)

--- a/lib/train/k8s/container/kubectl_exec_client.rb
+++ b/lib/train/k8s/container/kubectl_exec_client.rb
@@ -83,7 +83,7 @@ module Train
         end
 
         def sh_run_command(command)
-          %W{/bin/sh -c "#{command}"}
+          %W{/bin/sh -c "#{command}"}.join("\s")
         end
       end
     end

--- a/lib/train/k8s/container/kubectl_exec_client.rb
+++ b/lib/train/k8s/container/kubectl_exec_client.rb
@@ -34,26 +34,42 @@ module Train
           text.gsub(/\e\[.*?m/, "").gsub(/\e\]0;.*?\a/, "").gsub(/\e\[A/, "").gsub(/\e\[C/, "").gsub(/\e\[K/, "")
         end
 
-        def stream(command)
-          instruction = [].tap do |com|
-            com << sh_run_command(command)
-            com << sh_run_command("echo KUBECTL_EXEC_STATUS:$?")
-            com << sh_run_command("echo KUBECTL_EXEC_DONE")
-          end.join(";\s")
-          session.puts(instruction)
-          output = ""
-          exit_status = nil
-          while (line = session.gets)
-            if line.start_with?("KUBECTL_EXEC_STATUS:")
-              exit_status = line.chomp.split(":")[1].to_i
-            elsif line.chomp == "KUBECTL_EXEC_DONE"
-              break
-            else
-              output += line
+        def send_command(command)
+          @writer.puts("#{command} 2>&1 ; echo EXIT_CODE=$?")
+          @writer.flush
+
+          stdout = ""
+          stderr = ""
+          status = nil
+          buffer = ""
+
+          begin
+            while (line = @reader.gets)
+              buffer << line
+              if line =~ /EXIT_CODE=(\d+)/
+                status = $1.to_i
+                break
+              end
             end
+          rescue Errno::EIO
           end
-          if exit_status.nil?
-            puts "Error: Failed to retrieve exit status."
+
+          # Clean up the buffer by removing ANSI escape sequences
+          buffer = strip_ansi_sequences(buffer)
+          # Process the buffer to remove the command echo and the EXIT_CODE
+          stdout_lines = buffer.lines
+          # TODO: there is a known bug with this approach and that is if an executable that is not found in the
+          # environment is tried and executed, then it will remove not be present in the STDERR, because the following
+          # line filters that exact command as well for example,
+          # for the command 'foo'
+          # `["bash: foo: command not found\r\n"].reject! { |l| l =~ /#{Regexp.escape('foo')}/ }` returns an empty []
+          stdout_lines.reject! { |l| l =~ /#{Regexp.escape(command)}/ }
+          stdout_lines.reject! { |l| l =~ /EXIT_CODE=/ }
+
+          # Separate stdout and stderr
+          if status != 0
+            stderr = stdout_lines.join.strip
+            stdout = ""
           else
             stdout, stderr = if exit_status == 0
                                [output, ""]

--- a/lib/train/k8s/container/kubectl_exec_client.rb
+++ b/lib/train/k8s/container/kubectl_exec_client.rb
@@ -30,14 +30,8 @@ module Train
           Train::Extras::CommandResult.new("", "", 1)
         end
 
-        private
-
-        def session
-          @@session
-        end
-
-        def ensure_session_open
-          start_session unless session && !session.closed?
+        def strip_ansi_sequences(text)
+          text.gsub(/\e\[.*?m/, "").gsub(/\e\]0;.*?\a/, "").gsub(/\e\[A/, "").gsub(/\e\[C/, "").gsub(/\e\[K/, "")
         end
 
         def stream(command)

--- a/lib/train/k8s/container/kubectl_exec_client.rb
+++ b/lib/train/k8s/container/kubectl_exec_client.rb
@@ -71,19 +71,10 @@ module Train
             stderr = stdout_lines.join.strip
             stdout = ""
           else
-            stdout, stderr = if exit_status == 0
-                               [output, ""]
-                             else
-                               ["", output]
-                             end
+            stdout = stdout_lines.join.strip
           end
-          Train::Extras::CommandResult.new(stdout, stderr, exit_status)
-        end
 
-        def start_session
-          @@session = IO.popen(exec_command, "r+")
-          # TODO: check if kubectl connection is established
-          raise "Failed to open connection" unless @@session
+          Train::Extras::CommandResult.new(stdout, stderr, status)
         end
 
         def execute(command)

--- a/lib/train/k8s/container/kubectl_exec_client.rb
+++ b/lib/train/k8s/container/kubectl_exec_client.rb
@@ -9,6 +9,7 @@ module Train
         attr_reader :pod, :container_name, :namespace
 
         DEFAULT_NAMESPACE = "default".freeze
+        @@session = nil
 
         def initialize(pod:, namespace: nil, container_name: nil)
           @pod = pod
@@ -25,7 +26,9 @@ module Train
 
         private
 
-        attr_reader :session
+        def session
+          @@session
+        end
 
         def ensure_session_open
           start_session unless session && !session.closed?
@@ -57,9 +60,9 @@ module Train
         end
 
         def start_session
-          @session = IO.popen(exec_command, "r+")
+          @@session = IO.popen(exec_command, "r+")
           # TODO: check if kubectl connection is established
-          raise "Failed to open connection" unless @session
+          raise "Failed to open connection" unless @@session
         end
 
         def exec_command

--- a/lib/train/k8s/container/kubectl_exec_client.rb
+++ b/lib/train/k8s/container/kubectl_exec_client.rb
@@ -20,10 +20,13 @@ module Train
           @namespace = namespace
         end
 
-        def execute(command)
-          ensure_session_open
-          stream(command)
-        rescue Errno::ENOENT => _e
+        def disconnect
+          @writer.puts "exit" if @writer
+          [@reader, @writer].each do |io|
+            io.close if io && !io.closed?
+          end
+          @@session = {}
+        rescue IOError
           Train::Extras::CommandResult.new("", "", 1)
         end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Optimise the Persistent connection to K8s container

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Uses PTY to open a pseudo terminal with persistent connection to a K8s Container 
- User Kubectl exec with shell to login to pod for an interactive session
- Keeps the session for the whole process and ability to reconnect 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
